### PR TITLE
feat: port to 1.21.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'dev.architectury.loom' version '1.10-SNAPSHOT' apply false
+    id 'dev.architectury.loom' version '1.11-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.4-SNAPSHOT'
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
     id 'maven-publish'

--- a/common/src/main/java/pro/mikey/autoclicker/AutoClicker.java
+++ b/common/src/main/java/pro/mikey/autoclicker/AutoClicker.java
@@ -11,13 +11,12 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.LazyLoadedValue;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
-import org.apache.commons.lang3.concurrent.LazyInitializer;
+import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.glfw.GLFW;
@@ -33,10 +32,13 @@ import java.util.function.Supplier;
 public class AutoClicker {
     public static final String MOD_ID = "autoclicker";
     public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
+
+    private static final KeyMapping.Category KEYBIND_CATEGORY =
+            KeyMapping.Category.register(ResourceLocation.fromNamespaceAndPath(MOD_ID, "keybinding-title"));
     public static final KeyMapping openConfig =
-            new KeyMapping("keybinding.open-gui", GLFW.GLFW_KEY_O, "category.autoclicker-fabric");
+            new KeyMapping("keybinding.open-gui", GLFW.GLFW_KEY_O, KEYBIND_CATEGORY);
     public static final KeyMapping toggleHolding =
-            new KeyMapping("keybinding.toggle-hold", GLFW.GLFW_KEY_I, "category.autoclicker-fabric");
+            new KeyMapping("keybinding.toggle-hold", GLFW.GLFW_KEY_I, KEYBIND_CATEGORY);
 
     private static final Supplier<Pair<Path, Path>> CONFIG_PATHS = Suppliers.memoize(() -> {
         Path configDir = Paths.get(Minecraft.getInstance().gameDirectory.getPath() + "/config");

--- a/common/src/main/java/pro/mikey/autoclicker/OptionsScreen.java
+++ b/common/src/main/java/pro/mikey/autoclicker/OptionsScreen.java
@@ -7,6 +7,7 @@ import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.gui.screens.inventory.tooltip.DefaultTooltipPositioner;
+import net.minecraft.client.input.KeyEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import org.jetbrains.annotations.Nullable;
@@ -268,13 +269,14 @@ public class OptionsScreen extends Screen {
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyEvent event) {
+        int keyCode = event.key();
         if (keyCode == AutoClicker.openConfig.getDefaultKey().getValue()) {
             this.onClose();
             return true;
         }
 
-        return super.keyPressed(keyCode, scanCode, modifiers);
+        return super.keyPressed(event);
     }
 
     @Override

--- a/common/src/main/resources/assets/autoclicker/lang/en_us.json
+++ b/common/src/main/resources/assets/autoclicker/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "category.autoclicker-fabric": "Auto clicker",
+  "key.category.autoclicker.keybinding-title": "Auto Clicker",
   "keybinding.toggle-hold": "Toggle Holding keys",
   "keybinding.toggle-jump": "Toggle Holding jump",
   "keybinding.open-gui": "Open auto clicker GUI",

--- a/common/src/main/resources/assets/autoclicker/lang/es_es.json
+++ b/common/src/main/resources/assets/autoclicker/lang/es_es.json
@@ -1,5 +1,5 @@
 {
-  "category.autoclicker-fabric": "Auto clicker",
+  "key.category.autoclicker.keybinding-title": "Auto Clicker",
   "keybinding.toggle-hold": "Alternar Mantener teclas",
   "keybinding.toggle-jump": "Alternar Mantener salto",
   "keybinding.open-gui": "Abrir GUI de auto clicker",

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "modmenu" : ["pro.mikey.autoclicker.fabric.client.ModMenuAPIImpl"]
   },
   "depends": {
-    "fabricloader": ">=0.16.0",
+    "fabricloader": ">=0.17.2",
     "fabric": "*",
     "minecraft": ">=1.21",
     "java": ">=21"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,20 +3,20 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 21.6.0
+mod_version = 21.9.0
 maven_group = pro.mikey.autoclicker
 archives_name = autoclicker
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.6
+minecraft_version = 1.21.9
 
 # Dependencies
-fabric_loader_version=0.16.14
-fabric_api_version=0.128.1+1.21.6
-neoforge_version = 21.6.20-beta
+fabric_loader_version=0.17.2
+fabric_api_version=0.133.1+1.21.9
+neoforge_version = 21.9.9-beta
 
-modmenu = 15.0.0-beta.3
+modmenu = 16.0.0-rc.1
 
 curseforge_id=445095
 modrinth_id=r8axuw4u


### PR DESCRIPTION
- Key mapping categories, previously a String, are now a KeyMapping.Category record.
- net.minecraft.client.gui.screens.Screen.keyPressed is `public boolean keyPressed(KeyEvent event)` now.